### PR TITLE
Pull Request: TypeHinting and Readability

### DIFF
--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -57,7 +57,7 @@ def dap_attribute(key: str, value: Any) -> dap.Attribute:
 
 def dap_dimension(da: xr.DataArray) -> dap.Array:
     """Transform an xarray dimension into a DAP dimension"""
-    encoded_da: xr.DataArray = xr.conventions.encode_cf_variable(da)
+    encoded_da: xr.DataArray = xr.conventions.encode_cf_variable(da.variable)
 
     dim = dap.Array(
         name=da.name,

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -33,7 +33,8 @@ def dap_dtype(da: xr.DataArray):
         return dtype_dap[da.dtype]
     except KeyError as e:
         logger.warning(
-            f"Unable to match dtype for {da.name}. Going to assume string will work for now... ({e})",
+            f"Unable to match dtype for {da.name}. "
+            f"Going to assume string will work for now... ({e})",
         )
         return dap.String
 
@@ -96,8 +97,8 @@ def dap_dataset(ds: xr.Dataset, name: str) -> dap.Dataset:
     dataset.append(*dims.values())
 
     for var in ds.data_vars:
-        data_array = dap_grid(ds[var], dims)
-        dataset.append(data_array)
+        data_grid = dap_grid(ds[var], dims)
+        dataset.append(data_grid)
 
     for key, value in ds.attrs.items():
         dataset.append(dap_attribute(key, value))

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -11,7 +11,7 @@ import numpy as np
 import opendap_protocol as dap
 import xarray as xr
 
-logger = logging.getLogger("api")
+logger: logging.Logger = logging.getLogger("api")
 
 dtype_dap = {
     np.ubyte: dap.Byte,
@@ -24,7 +24,9 @@ dtype_dap = {
     np.str_: dap.String,
     np.int64: dap.Float64,  # not a direct mapping
 }
-dtype_dap = {np.dtype(k): v for k, v in dtype_dap.items()}
+dtype_dap: Dict[np.dtype, dap.DAPAtom] = {
+    np.dtype(k): v for k, v in dtype_dap.items()
+}
 
 
 def dap_dtype(da: xr.DataArray):
@@ -57,7 +59,7 @@ def dap_attribute(key: str, value: Any) -> dap.Attribute:
 
 def dap_dimension(da: xr.DataArray) -> dap.Array:
     """Transform an xarray dimension into a DAP dimension"""
-    encoded_da = xr.conventions.encode_cf_variable(da)
+    encoded_da: xr.DataArray = xr.conventions.encode_cf_variable(da)
 
     dim = dap.Array(
         name=da.name,
@@ -90,7 +92,7 @@ def dap_dataset(ds: xr.Dataset, name: str) -> dap.Dataset:
     """Create a DAP Dataset for an xarray Dataset"""
     dataset = dap.Dataset(name=name)
 
-    dims = {}
+    dims: Dict[str, dap.Array] = {}
     for dim in ds.dims:
         dims[dim] = dap_dimension(ds[dim])
 

--- a/xpublish_opendap/plugin.py
+++ b/xpublish_opendap/plugin.py
@@ -4,9 +4,6 @@ OpenDAP router for Xpublish
 """
 import logging
 from urllib import parse
-from typing import (
-    List,
-)
 
 import cachey
 import opendap_protocol as dap
@@ -18,25 +15,27 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 from xpublish import (
+    Dependencies,
     Plugin,
     hookimpl,
-    Dependencies,
 )
 
-import xpublish_opendap.dap_xarray as dap_xarray
+from xpublish_opendap import dap_xarray
 
 logger: logging.Logger = logging.getLogger("uvicorn")
 
 
 class OpenDapPlugin(Plugin):
+    """OpenDAP plugin for xpublish."""
+
     name: str = "opendap"
 
     dataset_router_prefix: str = "/opendap"
-    dataset_router_tags: List[str] = ["opendap"]
+    dataset_router_tags: list[str] = ["opendap"]
 
     @hookimpl
     def dataset_router(self, deps: Dependencies) -> APIRouter:
-
+        """Create an OpenDAP router for xpublish."""
         router = APIRouter(
             prefix=self.dataset_router_prefix,
             tags=self.dataset_router_tags,
@@ -47,10 +46,7 @@ class OpenDapPlugin(Plugin):
             ds: xr.Dataset = Depends(deps.dataset),
             cache: cachey.Cache = Depends(deps.cache),
         ) -> dap.Dataset:
-            """
-            Get a dataset that has been translated to opendap
-            """
-
+            """Get a dataset that has been translated to opendap."""
             # get cached dataset if it exists
             cache_key = f"opendap_dataset_{dataset_id}"
             dataset = cache.get(cache_key)
@@ -73,8 +69,7 @@ class OpenDapPlugin(Plugin):
             constraint=Depends(dap_constraint),
             dataset: dap.Dataset = Depends(get_dap_dataset),
         ) -> StreamingResponse:
-            """OpenDAP DDS response (types and dimension metadata)"""
-
+            """OpenDAP DDS response (types and dimension metadata)."""
             return StreamingResponse(
                 dataset.dds(constraint=constraint),
                 media_type="text/plain",
@@ -85,8 +80,7 @@ class OpenDapPlugin(Plugin):
             constraint=Depends(dap_constraint),
             dataset: dap.Dataset = Depends(get_dap_dataset),
         ) -> StreamingResponse:
-            """OpenDAP DAS response (attribute metadata)"""
-
+            """OpenDAP DAS response (attribute metadata)."""
             return StreamingResponse(
                 dataset.das(constraint=constraint),
                 media_type="text/plain",
@@ -97,8 +91,7 @@ class OpenDapPlugin(Plugin):
             constraint=Depends(dap_constraint),
             dataset: dap.Dataset = Depends(get_dap_dataset),
         ) -> StreamingResponse:
-            """OpenDAP dods response (data access)"""
-
+            """OpenDAP dods response (data access)."""
             return StreamingResponse(
                 dataset.dods(constraint=constraint),
                 media_type="application/octet-stream",

--- a/xpublish_opendap/plugin.py
+++ b/xpublish_opendap/plugin.py
@@ -24,17 +24,17 @@ from xpublish import (
 
 import xpublish_opendap.dap_xarray as dap_xarray
 
-logger = logging.getLogger("uvicorn")
+logger: logging.Logger = logging.getLogger("uvicorn")
 
 
 class OpenDapPlugin(Plugin):
-    name = "opendap"
+    name: str = "opendap"
 
-    dataset_router_prefix = "/opendap"
+    dataset_router_prefix: str = "/opendap"
     dataset_router_tags: List[str] = ["opendap"]
 
     @hookimpl
-    def dataset_router(self, deps: Dependencies):
+    def dataset_router(self, deps: Dependencies) -> APIRouter:
 
         router = APIRouter(
             prefix=self.dataset_router_prefix,
@@ -65,7 +65,6 @@ class OpenDapPlugin(Plugin):
         def dap_constraint(request: Request) -> str:
             """Parse DAP constraints from request"""
             constraint = parse.unquote(request.url.components[3])
-
             return constraint
 
         @router.get(".dds")

--- a/xpublish_opendap/plugin.py
+++ b/xpublish_opendap/plugin.py
@@ -10,7 +10,11 @@ from urllib import parse
 import cachey
 import opendap_protocol as dap
 import xarray as xr
-from fastapi import APIRouter, Depends, Request
+from fastapi import (
+    APIRouter,
+    Depends,
+    Request,
+)
 from fastapi.responses import StreamingResponse
 from xpublish import (
     Plugin,


### PR DESCRIPTION
Hello `xpublish-opendap` devs / @abkfenris. 

First off, great job making a very useful adaptor. I look forward to developing with it and sharing our work with the wider Xpublished community in the near future.

TLDR: **I made no functional changes to the repo code at all! Behavior was not modified in any way.** I hope you consider reviewing and pulling in these edits, as I'd argue they improve the readability and understandability of the code, which only encourages more use and contributions.

Readability edits:
As I began working with the repo, I noticed readability could be improved to match the standards set by the [Google Python StyleGuide](https://google.github.io/styleguide/pyguide.html) as well as [PEP8](https://peps.python.org/pep-0008/) (i.e., column limits, #-out-able imports/function-arguments, relative "." imports, spacing between functions, etc.).

TypeHinting Edits:
TypeHinting was somewhat inconsistent (missing for a few functions) and personally I am a big fan of "idiot-proofing" repositories via very explicit TypeHinting (including in-line hinting for variables returned by functions). 

An example of this to illustrate my thinking where I attempt to make clear the underlying type shared by all `opendap_protocol` datatypes:
```python
# BEFORE
dtype_dap = {np.dtype(k): v for k, v in dtype_dap.items()}

# AFTER:
dtype_dap: Dict[np.dtype, dap.DAPAtom] = {
    np.dtype(k): v for k, v in dtype_dap.items()
}
```

All my edits are incredibly minor, but since I hope more people use this code going forward, adding that final but of polish seems worth it.

Thank you for your consideration!