### PR TITLE
Bug Fix: Preventing failure when dataset contains a non-numerica data-variable

### DIFF
--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -80,15 +80,9 @@ def dap_dimension(da: xr.DataArray) -> dap.Array:
 
 def dap_grid(da: xr.DataArray, dims: dict[str, dap.Array]) -> dap.Grid:
     """Transform an xarray DataArray into a DAP Grid."""
-    # get encoding dtype (should exist for numeric dtypes)
-    try:
-        encoding_dtype = da.encoding["dtype"]
-    except KeyError:
-        raise NoEncodingDtype from KeyError
-
     data_grid = dap.Grid(
         name=da.name,
-        data=da.astype(encoding_dtype).data,
+        data=da.astype(da.encoding["dtype"]).data,
         dtype=dap_dtype(da),
         dimensions=[dims[dim] for dim in da.dims],
     )

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -84,7 +84,7 @@ def dap_grid(da: xr.DataArray, dims: dict[str, dap.Array]) -> dap.Grid:
     try:
         encoding_dtype = da.encoding["dtype"]
     except KeyError:
-        raise NoEncodingDtype
+        raise NoEncodingDtype from KeyError
 
     data_grid = dap.Grid(
         name=da.name,

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -13,6 +13,7 @@ logger: logging.Logger = logging.getLogger("api")
 
 class NoEncodingDtype(KeyError):
     """Exception for when no encoding dtype is found."""
+
     ...
 
 

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -73,9 +73,14 @@ def dap_dimension(da: xr.DataArray) -> dap.Array:
 
 def dap_grid(da: xr.DataArray, dims: dict[str, dap.Array]) -> dap.Grid:
     """Transform an xarray DataArray into a DAP Grid."""
+    try:
+        encoding_dtype = da.encoding["dtype"]
+    except KeyError:
+        encoding_dtype = da.dtype
+
     data_grid = dap.Grid(
         name=da.name,
-        data=da.astype(da.encoding["dtype"]).data,
+        data=da.astype(encoding_dtype).data,
         dtype=dap_dtype(da),
         dimensions=[dims[dim] for dim in da.dims],
     )


### PR DESCRIPTION
Hi @abkfenris it is me again. I added a bug fix to allow a server to pass over a non-numeric data-variable without throwing an error.

Issue: If a dataset contains a non-numeric data-variable (for instance, [OSN data](https://www.openstoragenetwork.org/motivation/our-policy/) often has "name" stored as a dtype="U11" data-array), the code would look for "dtype" within `ds['non_numeric_var'].encoding` which would not exist. A KeyError would be raised, and the server would fail to serve any data.

Solution: I made a custom exception that inherits from KeyError (`NoEncodingDtype`) that is thrown in this specific case only (i.e., 'dtype' not in `ds[var]encoding.keys()`). If thrown, when the `dap.Grid` object is being built, a warning message is logged, and the non-numeric variable is skipped over.

All pre-commit hooks were passed, so this time it should go through without problems? Let me know if you want me to adjust anything.
