### PR TITLE
provision-with-micromamba is deprecated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,26 +16,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@v15
+      - name: Setup Micromamba ${{ matrix.python-version }}
+        uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: false
+          environment-name: TEST
+          init-shell: bash
+          create-args: >-
+            python=${{ matrix.python-version }} pip
+            --file requirements.txt
+            --file requirements-dev.txt
+            --channel conda-forge
 
-      - name: Python ${{ matrix.python-version }}
+      - name: Install xpublish-opendap
         shell: bash -l {0}
         run: >
-          micromamba create --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
-          && micromamba activate TEST
-          && pip install git+https://github.com/xpublish-community/xpublish.git
-          && pip install -e . --no-deps --force-reinstall
+          python -m pip install git+https://github.com/xpublish-community/xpublish.git
+          && python -m pip install -e . --no-deps --force-reinstall
           && micromamba info
           && micromamba list
 
       - name: Tests
         shell: bash -l {0}
-        run: >
-          micromamba activate TEST
-          && pytest -rxs --cov=xpublish_opendap --cov-report=xml tests
+        run: |
+          python -m pytest -rxs --cov=xpublish_opendap --cov-report=xml tests
 
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
The mamba-org/provision-with-micromamba GHA is deprecated in lieu of mamba-org/setup-micromamba.