### PR TITLE
Accessing dtype via `.dtype` attribute as opposed to `encoding` hash map

### DIFF
--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -2,6 +2,7 @@
 import logging
 from typing import (
     Any,
+    Union,
 )
 
 import numpy as np
@@ -21,13 +22,13 @@ dtype_dap = {
     np.str_: dap.String,
     np.int64: dap.Float64,  # not a direct mapping
 }
-dap_dtypes_dict: dict[np.dtype, dap.DAPAtom] = {
+dap_dtypes_dict: dict[Union[str, np.dtype], type[dap.DAPAtom]] = {
     np.dtype(k): v for k, v in dtype_dap.items()
 }
 del dtype_dap
 
 
-def dap_dtype(da: xr.DataArray):
+def dap_dtype(da: xr.DataArray | xr.Variable) -> type[dap.DAPAtom]:
     """Return a DAP type for the xr.DataArray."""
     try:
         return dap_dtypes_dict[np.dtype(da.dtype)]
@@ -57,7 +58,11 @@ def dap_attribute(key: str, value: Any) -> dap.Attribute:
 
 def dap_dimension(da: xr.DataArray) -> dap.Array:
     """Transform an xarray dimension into a DAP dimension."""
-    encoded_da: xr.DataArray = xr.conventions.encode_cf_variable(da.variable)
+    encoded_da: xr.Variable = xr.conventions.encode_cf_variable(da.variable)
+
+    # protect against reverse encoding not matching to dap.DAPAtom dtypes
+    if str(encoded_da.dtype).startswith(">"):
+        encoded_da = encoded_da.astype(str(encoded_da.dtype).replace(">", "<"))
 
     dim = dap.Array(
         name=da.name,

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -32,6 +32,7 @@ def dap_dtype(da: xr.DataArray):
     try:
         return dap_dtypes_dict[da.dtype]
     except KeyError as e:
+        raise KeyError
         logger.warning(
             f"Unable to match dtype={da.dtype} for {getattr(da, 'name', 'DataArray')}. "
             f"Going to assume string will work for now... ({e})",

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -31,7 +31,7 @@ del dtype_dap
 def dap_dtype(da: Union[xr.DataArray, xr.Variable]) -> type[dap.DAPAtom]:
     """Return a DAP type for the xr.DataArray."""
     try:
-        return dap_dtypes_dict[np.dtype(da.dtype)]
+        return dap_dtypes_dict[da.dtype]
     except KeyError as e:
         logger.warning(
             f"Unable to match dtype={da.dtype} for {getattr(da, 'name', 'DataArray')}. "

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -30,9 +30,8 @@ del dtype_dap
 def dap_dtype(da: xr.DataArray):
     """Return a DAP type for the xr.DataArray."""
     try:
-        return dap_dtypes_dict[da.dtype]
+        return dap_dtypes_dict[np.dtype(da.dtype)]
     except KeyError as e:
-        raise KeyError(f'{da.dtype} not found in {dap_dtypes_dict}')
         logger.warning(
             f"Unable to match dtype={da.dtype} for {getattr(da, 'name', 'DataArray')}. "
             f"Going to assume string will work for now... ({e})",

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -33,7 +33,7 @@ def dap_dtype(da: xr.DataArray):
         return dap_dtypes_dict[da.dtype]
     except KeyError as e:
         logger.warning(
-            f"Unable to match dtype for {da.name}. "
+            f"Unable to match dtype for {getattr(da, 'name', 'DataArray')}. "
             f"Going to assume string will work for now... ({e})",
         )
         return dap.String

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -33,7 +33,7 @@ def dap_dtype(da: xr.DataArray):
         return dap_dtypes_dict[da.dtype]
     except KeyError as e:
         logger.warning(
-            f"Unable to match dtype for {getattr(da, 'name', 'DataArray')}. "
+            f"Unable to match dtype={da.dtype} for {getattr(da, 'name', 'DataArray')}. "
             f"Going to assume string will work for now... ({e})",
         )
         return dap.String

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -75,7 +75,7 @@ def dap_grid(da: xr.DataArray, dims: dict[str, dap.Array]) -> dap.Grid:
     """Transform an xarray DataArray into a DAP Grid."""
     data_grid = dap.Grid(
         name=da.name,
-        data=da.astype(da.encoding["dtype"]).data,
+        data=da.astype(da.dtype).data,
         dtype=dap_dtype(da),
         dimensions=[dims[dim] for dim in da.dims],
     )

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -32,7 +32,7 @@ def dap_dtype(da: xr.DataArray):
     try:
         return dap_dtypes_dict[da.dtype]
     except KeyError as e:
-        raise KeyError
+        raise KeyError(f'{da.dtype} not found in {dap_dtypes_dict}')
         logger.warning(
             f"Unable to match dtype={da.dtype} for {getattr(da, 'name', 'DataArray')}. "
             f"Going to assume string will work for now... ({e})",

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -22,7 +22,7 @@ dtype_dap = {
     np.str_: dap.String,
     np.int64: dap.Float64,  # not a direct mapping
 }
-dap_dtypes_dict: dict[Union[str, np.dtype], type[dap.DAPAtom]] = {
+dap_dtypes_dict: dict[np.dtype, type[dap.DAPAtom]] = {
     np.dtype(k): v for k, v in dtype_dap.items()
 }
 del dtype_dap

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -34,7 +34,7 @@ def dap_dtype(da: Union[xr.DataArray, xr.Variable]) -> type[dap.DAPAtom]:
         return dap_dtypes_dict[da.dtype]
     except KeyError as e:
         logger.warning(
-            f"Unable to match dtype={da.dtype} for {getattr(da, 'name', 'DataArray')}. "
+            f"Unable to match dtype={da.dtype} for {getattr(da, 'name', type(da))}. "
             f"Going to assume string will work for now... ({e})",
         )
         return dap.String

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -28,7 +28,7 @@ dap_dtypes_dict: dict[Union[str, np.dtype], type[dap.DAPAtom]] = {
 del dtype_dap
 
 
-def dap_dtype(da: xr.DataArray | xr.Variable) -> type[dap.DAPAtom]:
+def dap_dtype(da: Union[xr.DataArray, xr.Variable]) -> type[dap.DAPAtom]:
     """Return a DAP type for the xr.DataArray."""
     try:
         return dap_dtypes_dict[np.dtype(da.dtype)]


### PR DESCRIPTION
Closes #45 

A simple fix to use the `xarray.Dataset(...).dtpye` attribute to read dtype as opposed to accessing the `encoding` hashmap, which may be wiped or empty in certain conditions.