### PR TITLE
Support SingleDatasetRest

### DIFF
--- a/tests/test_opendap_router.py
+++ b/tests/test_opendap_router.py
@@ -69,3 +69,68 @@ def test_dods_response(dap_client):
     assert "Float32 lon[lon = 53]" in text_content
     assert "Grid {" in text_content
     assert "Float64 air[time = 2920][lat = 25][lon = 53]" in text_content
+
+
+@pytest.fixture(scope="session")
+def dap_single_xpublish(dataset):
+    rest = xpublish.SingleDatasetRest(dataset, plugins={"opendap": OpenDapPlugin()})
+
+    return rest
+
+
+@pytest.fixture(scope="session")
+def dap_single_client(dap_single_xpublish):
+    app = dap_single_xpublish.app
+    client = TestClient(app)
+
+    return client
+
+
+def test_single_dds_response(dap_single_client):
+    response = dap_single_client.get("/opendap.dds")
+
+    assert response.status_code == 200, "Response did not return successfully"
+
+    content = response.content.decode("utf-8")
+
+    assert "Dataset" in content
+    assert "Float32 lat[lat = 25]" in content
+    assert "Float32 time[time = 2920]" in content
+    assert "Float32 lon[lon = 53]" in content
+    assert "Grid {" in content
+    assert "Float64 air[time = 2920][lat = 25][lon = 53]" in content
+
+
+def test_single_das_response(dap_single_client):
+    response = dap_single_client.get("/opendap.das")
+
+    assert response.status_code == 200, "Response did not return successfully"
+
+    content = response.content.decode("utf-8")
+
+    assert "Attributes" in content
+    assert 'String standard_name "latitude"' in content
+    assert 'String standard_name "time"' in content
+    assert 'String standard_name "longitude"' in content
+    assert (
+        'String long_name "4xDaily Air temperature at sigma level 995"' in content
+    ), "long_name attribute missing from air DataArray"
+    assert (
+        'String title "4x daily NMC reanalysis (1948)"' in content
+    ), "Global attributes are returned"
+
+
+def test_single_dods_response(dap_single_client):
+    response = dap_single_client.get("/opendap.dods")
+
+    assert response.status_code == 200, "Response did not return successfully"
+    assert isinstance(response.content, bytes), "DODS Response content is not bytes"
+
+    text_content = response.text
+
+    assert "Dataset {" in text_content
+    assert "Float32 lat[lat = 25]" in text_content
+    assert "Float32 time[time = 2920]" in text_content
+    assert "Float32 lon[lon = 53]" in text_content
+    assert "Grid {" in text_content
+    assert "Float64 air[time = 2920][lat = 25][lon = 53]" in text_content

--- a/xpublish_opendap/plugin.py
+++ b/xpublish_opendap/plugin.py
@@ -43,7 +43,7 @@ class OpenDapPlugin(Plugin):
         )
 
         def get_dap_dataset(
-            dataset_id: str,
+            dataset_id: str = "default",
             ds: xr.Dataset = Depends(deps.dataset),
             cache: cachey.Cache = Depends(deps.cache),
         ) -> dap.Dataset:


### PR DESCRIPTION
Adds support for the `SingleDatasetRest` pattern by making the `dataset_id` arugment to the cache have a default value (of 'default'), in case there is not a `dataset_id` in the path.

Closes  #69