### PR TITLE
Fix datetime/timedelta data variables corrupting the DODS stream

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -14,8 +14,31 @@ ds_attrs_cast = xarray.tutorial.open_dataset("air_temperature")
 ds_attrs_cast.attrs["npint"] = np.int16(16)
 ds_attrs_cast.attrs["npintthirtytwo"] = np.int32(32)
 
+# Dataset with datetime64/timedelta64 *data variables* (not dimension
+# coordinates), e.g. CF time-bounds style variables. These have no DAP dtype
+# and must be CF-encoded to numeric before serialization. See test_time_vars.
+ds_time_vars = xarray.Dataset(
+    {
+        "temp": (("member", "lead"), np.zeros((3, 4), dtype="float32")),
+        "start_time": (
+            ("member", "lead"),
+            np.broadcast_to(np.datetime64("1965-01-01"), (3, 4)).copy(),
+        ),
+        "duration": (
+            ("member", "lead"),
+            np.full((3, 4), np.timedelta64(365, "D")),
+        ),
+    },
+    coords={"member": np.arange(3), "lead": np.arange(4)},
+)
+
 rest = xpublish.Rest(
-    {"air": ds, "attrs_quote": ds_attrs_quote, "attrs_cast": ds_attrs_cast},
+    {
+        "air": ds,
+        "attrs_quote": ds_attrs_quote,
+        "attrs_cast": ds_attrs_cast,
+        "time_vars": ds_time_vars,
+    },
     plugins={"opendap": OpenDapPlugin()},
 )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ Live tests are currently failing on Windows, see:
 import sys
 
 import netCDF4
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -63,6 +64,28 @@ def test_attrs_quotes(xpublish_server):
     ds = xr.open_dataset(url)
 
     assert ds.attrs["quotes"] == 'This attribute uses "quotes"'
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="NetCDF4 is failing on Windows Github Actions workers",
+)
+def test_time_vars(xpublish_server):
+    """Datetime/timedelta data variables must be readable.
+
+    Regression test: datetime64/timedelta64 *data variables* (e.g. CF time
+    bounds) have no DAP dtype. Previously they were emitted as malformed String
+    arrays, corrupting the DODS stream so that every variable failed with
+    ``NetCDF: Index exceeds dimension bound``. They must now CF-encode to
+    numeric and read back as times.
+    """
+    url = f"{xpublish_server}/datasets/time_vars/opendap"
+    ds = xr.open_dataset(url)
+
+    # Reading any variable's values must not raise (the whole stream is sound).
+    assert ds["temp"].values.shape == (3, 4)
+    assert (ds["start_time"].values == np.datetime64("1965-01-01")).all()
+    assert (ds["duration"].values == np.timedelta64(365, "D")).all()
 
 
 @pytest.mark.skipif(

--- a/xpublish_opendap/dap_xarray.py
+++ b/xpublish_opendap/dap_xarray.py
@@ -67,13 +67,32 @@ def dap_attribute(key: str, value: Any) -> dap.Attribute:
     )
 
 
-def dap_dimension(da: xr.DataArray) -> dap.Array:
-    """Transform an xarray dimension into a DAP dimension."""
-    encoded_da: xr.Variable = xr.conventions.encode_cf_variable(da.variable)
+def _encode_cf(da: xr.DataArray | xr.Variable) -> xr.Variable:
+    """CF-encode a variable to its numeric on-disk representation.
+
+    DAP has no equivalent for ``datetime64``/``timedelta64`` dtypes. Without
+    encoding, :func:`dap_dtype` falls back to :class:`dap.String`, and
+    ``opendap_protocol`` then emits an invalid String-array encoding that
+    desynchronizes the entire DODS byte stream (clients report
+    ``NetCDF: Index exceeds dimension bound``). Encoding turns these into the
+    numeric CF form (e.g. ``float64`` with ``units``/``calendar`` attributes)
+    that serializes correctly and that clients decode back to times.
+
+    Laziness is preserved: encoding dask-backed data returns dask-backed data.
+    """
+    variable = da.variable if isinstance(da, xr.DataArray) else da
+    encoded: xr.Variable = xr.conventions.encode_cf_variable(variable)
 
     # protect against reverse encoding not matching to dap.DAPAtom dtypes
-    if str(encoded_da.dtype).startswith(">"):
-        encoded_da = encoded_da.astype(str(encoded_da.dtype).replace(">", "<"))
+    if str(encoded.dtype).startswith(">"):
+        encoded = encoded.astype(str(encoded.dtype).replace(">", "<"))
+
+    return encoded
+
+
+def dap_dimension(da: xr.DataArray) -> dap.Array:
+    """Transform an xarray dimension into a DAP dimension."""
+    encoded_da = _encode_cf(da)
 
     dim = dap.Array(
         name=da.name,
@@ -89,14 +108,22 @@ def dap_dimension(da: xr.DataArray) -> dap.Array:
 
 def dap_grid(da: xr.DataArray, dims: dict[str, dap.Array]) -> dap.Grid:
     """Transform an xarray DataArray into a DAP Grid."""
+    variable: xr.DataArray | xr.Variable = da
+    # datetime64 ("M") / timedelta64 ("m") data variables (e.g. CF time bounds)
+    # must be CF-encoded to numeric, the same way dimension coordinates are, or
+    # they fall through to the broken String fallback. Other dtypes are left
+    # untouched to preserve their existing on-the-wire representation.
+    if da.dtype.kind in ("M", "m"):
+        variable = _encode_cf(da)
+
     data_grid = dap.Grid(
         name=da.name,
-        data=da.data,
-        dtype=dap_dtype(da),
+        data=variable.data,
+        dtype=dap_dtype(variable),
         dimensions=[dims[dim] for dim in da.dims],
     )
 
-    for key, value in da.attrs.items():
+    for key, value in variable.attrs.items():
         data_grid.append(dap_attribute(key, value))
 
     return data_grid


### PR DESCRIPTION
## Problem

`datetime64`/`timedelta64` **data variables** — for example CF time-bounds style variables such as `average_T1`, `average_T2`, `average_DT` — are unreadable over OPeNDAP. A netCDF-C client (ncdump, PyFerret, `xarray.open_dataset`) fails on **every** variable in the dataset with:

```
NetCDF: Index exceeds dimension bound (OPeNDAP/netCDF Error code -40)
```

### Root cause

`dap_dtype` has no mapping for `datetime64`/`timedelta64`, so it falls back to `dap.String` (with only a warning). `opendap_protocol` then serializes the "String" array by writing a numeric-style length prefix followed by a raw `astype('S')` blob — e.g. the literal bytes `315360000000000000 nan315360000000000000 nan...` for a 1-year `timedelta64`. That is not valid DAP2 String-array framing, so it desynchronizes the entire DODS byte stream and the client mis-reads every subsequent variable.

This only affects **data variables**. Dimension coordinates (e.g. a `time` axis) already work, because `dap_dimension` runs them through `xr.conventions.encode_cf_variable` first. `dap_grid` did not — that asymmetry is the bug.

## Fix

Apply the same CF-encoding to time-typed data variables that dimension coordinates already get:

- Factor the encode-and-guard logic into a shared `_encode_cf` helper.
- In `dap_grid`, encode variables whose dtype kind is `"M"` (datetime64) or `"m"` (timedelta64) to their numeric CF representation (e.g. `float64` with `units`/`calendar`), which serializes correctly and which clients decode back to times.

Scoping choices:
- **Only `M`/`m` dtypes are re-encoded**, so the on-the-wire representation of all other variables (including packed `int16` + scale/offset) is unchanged.
- **Laziness is preserved** — `encode_cf_variable` keeps dask-backed data dask-backed, so large arrays still stream chunked rather than loading into memory.

## Test

Added `test_time_vars`: a dataset with `datetime64` and `timedelta64` **data variables**, read back through a real netCDF4 client and asserted to round-trip. The existing tests only ever exercised time as a *dimension coordinate*, which is why this slipped through.

Verified the new test **fails on `main`** (reproduces the `Index exceeds dimension bound` corruption) and **passes with this change**; the existing suite continues to pass.

## Possible follow-up (not in this PR)

`dap_dtype` still silently downgrades any unmapped dtype to `dap.String` with only a log warning, which produces a corrupt stream rather than a clear error. Might be worth making that path fail loudly.

---
🤖 This PR was prepared by Claude Code on behalf of @mpiannucci.